### PR TITLE
fix no more polling when last Host entry returned an error, add testing and more

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+.gitignore
+test
+.travis.yml
+appveyor.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+os:
+  - linux
+  - osx
+language: node_js
+node_js:
+  - "0.10"
+  - "0.12"
+  - "4"
+  - "6"
+before_script:
+  - npm install winston@2.3.0
+  - npm install https://github.com/ioBroker/ioBroker.js-controller/tarball/master --production
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ os:
   - osx
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
   - "6"
 before_script:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 ![Logo](admin/tr-064.png)
 
-#### ioBroker.tr-064 
+#### ioBroker.tr-064
 ioBroker Adapter for tr-064 devices
+
+***This adapter requires at least Node 4.x***
 
 #### Info
 
@@ -10,7 +12,7 @@ https://avm.de/service/schnittstellen/
 #### Installation
 Execute the following command in the iobroker root directory (e.g. in /opt/iobroker)
 ```
-npm install iobroker.tr-064 
+npm install iobroker.tr-064
 ```
 ### License
 The MIT License (MIT)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,35 @@
+version: 'test-{build}'
+
+# Test against this version of Node.js
+environment:
+  matrix:
+    - nodejs_version: "0.10"
+    - nodejs_version: "0.12"
+    - nodejs_version: "4"
+    - nodejs_version: "6"
+
+platform:
+  - x86
+  - x64
+
+clone_folder: c:\projects\%APPVEYOR_PROJECT_NAME%
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version $env:platform
+  # install modules
+  - npm install
+  - npm install winston@2.3.0
+  - npm install https://github.com/ioBroker/ioBroker.js-controller/tarball/master --production
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - echo %cd%
+  - node --version
+  - npm --version
+  # run tests
+  - npm test
+
+# Don't actually build.
+build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,6 @@ version: 'test-{build}'
 # Test against this version of Node.js
 environment:
   matrix:
-    - nodejs_version: "0.10"
-    - nodejs_version: "0.12"
     - nodejs_version: "4"
     - nodejs_version: "6"
 

--- a/lib/callmonitor.js
+++ b/lib/callmonitor.js
@@ -1,6 +1,8 @@
-"use strict";
+/* jshint -W097 */// jshint strict:false
+/*jslint node: true */
+'use strict';
 
-const CALLMONITOR_NAME = 'callmonitor';
+var CALLMONITOR_NAME = 'callmonitor';
 
 module.exports = function (adapter, devices, phonebook) {
     if (!adapter.config.useCallMonitor) return;
@@ -36,7 +38,7 @@ module.exports = function (adapter, devices, phonebook) {
         var timer = null;
 
         function set(name) {
-            if (timer) cancelTimeout(timer);
+            if (timer) clearTimeout(timer);
             dev.setChannel(name, name);
             for (var i in message) {
                 if (i[0] != '_') dev.set(i, message[i]);
@@ -44,7 +46,7 @@ module.exports = function (adapter, devices, phonebook) {
             dev.set('timestamp', timestamp);
             message._type = name;
             if (adapter.config.usePhonebook && phonebook) {
-                if (message.callerName == undefined && message.caller) {
+                if (message.callerName === undefined && message.caller) {
                     message.callerName = phonebook.findNumber(message.caller);
                 }
                 dev.set('callerName', message.callerName);

--- a/lib/callmonitor.js
+++ b/lib/callmonitor.js
@@ -2,7 +2,7 @@
 /*jslint node: true */
 'use strict';
 
-var CALLMONITOR_NAME = 'callmonitor';
+const CALLMONITOR_NAME = 'callmonitor';
 
 module.exports = function (adapter, devices, phonebook) {
     if (!adapter.config.useCallMonitor) return;

--- a/lib/phonebook.js
+++ b/lib/phonebook.js
@@ -75,7 +75,7 @@ Phonebook.prototype.read = function (bo, cb) {
         var no = 0;
         self.length = 0; //phoneBook = [];
 
-        var url = require('url'),
+        const url = require('url'),
             Parser = new require('xml2js').Parser({
                 explicitArray: false,
                 mergeAttrs: true,

--- a/lib/phonebook.js
+++ b/lib/phonebook.js
@@ -1,4 +1,6 @@
-"use strict";
+/* jshint -W097 */// jshint strict:false
+/*jslint node: true */
+'use strict';
 
 function Phonebook () {
     Array.call(this);
@@ -11,7 +13,7 @@ Phonebook.prototype = Object.create(Array.prototype);
 
 Phonebook.prototype.start = function (sslDevice, cb, options) {
     this.init(sslDevice, function(err,res) {
-        this.read(cb)
+        this.read(cb);
     }.bind(this), options);
 };
 
@@ -21,10 +23,10 @@ var adapter = {
 
 Phonebook.prototype.init = function (sslDevice, cb, options) {
     var _adapter;
-    if (options != undefined) {
+    if (options !== undefined) {
         _adapter = options.adapter;
     }
-    if (module.parent.exports.adapter != undefined) {
+    if (module.parent.exports.adapter !== undefined) {
         adapter = module.parent.exports.adapter;
     } else if (_adapter) {
         adapter = _adapter;
@@ -59,7 +61,7 @@ Phonebook.prototype.init = function (sslDevice, cb, options) {
 };
 
 Phonebook.prototype.read = function (bo, cb) {
-    if (bo == undefined || typeof bo == 'function') {
+    if (bo === undefined || typeof bo === 'function') {
         cb = bo;
     }
     if (!bo) return cb ? cb(0) : 0;
@@ -73,7 +75,7 @@ Phonebook.prototype.read = function (bo, cb) {
         var no = 0;
         self.length = 0; //phoneBook = [];
 
-        const url = require('url'),
+        var url = require('url'),
             Parser = new require('xml2js').Parser({
                 explicitArray: false,
                 mergeAttrs: true,
@@ -141,16 +143,16 @@ Phonebook.prototype.start = function (sslDevice, cb, options) {
         options = cb;
         cb = _cb;
     }
-    if (options != undefined && options.return) return cb?cb(0):0;
+    if (options !== undefined && options.return) return cb?cb(0):0;
     this.init(sslDevice, function(err, res) {
-        this.read(cb)
+        this.read(cb);
     }.bind(this), options);
 };
 
 Phonebook.prototype.complete = function (number) {
     number = number.normalizeNumber();
-    if (this.areaCode != "") {
-        if (this.countryAndAreaCode != "" && number.indexOf(this.countryAndAreaCode) != 0) {
+    if (this.areaCode !== "") {
+        if (this.countryAndAreaCode !== "" && number.indexOf(this.countryAndAreaCode) !== 0) {
             if (number[0] == '0') {
                 if (number.substr(0, 2) == '00') return number;
                 return this.countryCode + number.substr(1);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,14 @@
     "tr-O64": "^0.2.1",
     "xml2js": "^0.4.17"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "mocha": "^2.3.4",
+    "chai": "^3.4.1"
+  },
+  "main": "tr-064.js",
+  "scripts": {
+    "test": "node node_modules/mocha/bin/mocha"
+  },
   "bugs": {
     "url": "https://github.com/soef/iobroker.tr-064/issues"
   },

--- a/test/lib/setup.js
+++ b/test/lib/setup.js
@@ -1,0 +1,675 @@
+/* jshint -W097 */// jshint strict:false
+/*jslint node: true */
+// check if tmp directory exists
+var fs            = require('fs');
+var path          = require('path');
+var child_process = require('child_process');
+var rootDir       = path.normalize(__dirname + '/../../');
+var pkg           = require(rootDir + 'package.json');
+var debug         = typeof v8debug === 'object';
+
+var adapterName = path.normalize(rootDir).replace(/\\/g, '/').split('/');
+adapterName = adapterName[adapterName.length - 2];
+
+function getAppName() {
+    var parts = __dirname.replace(/\\/g, '/').split('/');
+    return parts[parts.length - 3].split('.')[0];
+}
+
+var appName = getAppName().toLowerCase();
+
+var objects;
+var states;
+
+var pid = null;
+
+function copyFileSync(source, target) {
+
+    var targetFile = target;
+
+    //if target is a directory a new file with the same name will be created
+    if (fs.existsSync(target)) {
+        if ( fs.lstatSync( target ).isDirectory() ) {
+            targetFile = path.join(target, path.basename(source));
+        }
+    }
+
+    fs.writeFileSync(targetFile, fs.readFileSync(source));
+}
+
+function copyFolderRecursiveSync(source, target, ignore) {
+    var files = [];
+
+    var base = path.basename(source);
+    if (base === adapterName) {
+        base = pkg.name;
+    }
+    //check if folder needs to be created or integrated
+    var targetFolder = path.join(target, base);
+    if (!fs.existsSync(targetFolder)) {
+        fs.mkdirSync(targetFolder);
+    }
+
+    //copy
+    if (fs.lstatSync(source).isDirectory()) {
+        files = fs.readdirSync(source);
+        files.forEach(function (file) {
+            if (ignore && ignore.indexOf(file) !== -1) {
+                return;
+            }
+
+            var curSource = path.join(source, file);
+            if (fs.lstatSync(curSource).isDirectory()) {
+                // ignore grunt files
+                if (file.indexOf('grunt') !== -1) return;
+                if (file === 'chai') return;
+                if (file === 'mocha') return;
+                copyFolderRecursiveSync(curSource, targetFolder, ignore);
+            } else {
+                copyFileSync(curSource, targetFolder);
+            }
+        });
+    }
+}
+
+if (!fs.existsSync(rootDir + 'tmp')) {
+    fs.mkdirSync(rootDir + 'tmp');
+}
+
+function storeOriginalFiles() {
+    console.log('Store original files...');
+    var dataDir = rootDir + 'tmp/' + appName + '-data/';
+
+    var f = fs.readFileSync(dataDir + 'objects.json');
+    var objects = JSON.parse(f.toString());
+    if (objects['system.adapter.admin.0'] && objects['system.adapter.admin.0'].common) {
+        objects['system.adapter.admin.0'].common.enabled = false;
+    }
+    if (objects['system.adapter.admin.1'] && objects['system.adapter.admin.1'].common) {
+        objects['system.adapter.admin.1'].common.enabled = false;
+    }
+
+    fs.writeFileSync(dataDir + 'objects.json.original', JSON.stringify(objects));
+    try {
+        f = fs.readFileSync(dataDir + 'states.json');
+        fs.writeFileSync(dataDir + 'states.json.original', f);
+    }
+    catch (err) {
+        console.log('no states.json found - ignore');
+    }
+}
+
+function restoreOriginalFiles() {
+    console.log('restoreOriginalFiles...');
+    var dataDir = rootDir + 'tmp/' + appName + '-data/';
+
+    var f = fs.readFileSync(dataDir + 'objects.json.original');
+    fs.writeFileSync(dataDir + 'objects.json', f);
+    try {
+        f = fs.readFileSync(dataDir + 'states.json.original');
+        fs.writeFileSync(dataDir + 'states.json', f);
+    }
+    catch (err) {
+        console.log('no states.json.original found - ignore');
+    }
+
+}
+
+function checkIsAdapterInstalled(cb, counter, customName) {
+    customName = customName || pkg.name.split('.').pop();
+    counter = counter || 0;
+    var dataDir = rootDir + 'tmp/' + appName + '-data/';
+    console.log('checkIsAdapterInstalled...');
+
+    try {
+        var f = fs.readFileSync(dataDir + 'objects.json');
+        var objects = JSON.parse(f.toString());
+        if (objects['system.adapter.' + customName + '.0']) {
+            console.log('checkIsAdapterInstalled: ready!');
+            setTimeout(function () {
+                if (cb) cb();
+            }, 100);
+            return;
+        } else {
+            console.warn('checkIsAdapterInstalled: still not ready');
+        }
+    } catch (err) {
+
+    }
+
+    if (counter > 20) {
+        console.error('checkIsAdapterInstalled: Cannot install!');
+        if (cb) cb('Cannot install');
+    } else {
+        console.log('checkIsAdapterInstalled: wait...');
+        setTimeout(function() {
+            checkIsAdapterInstalled(cb, counter + 1);
+        }, 1000);
+    }
+}
+
+function checkIsControllerInstalled(cb, counter) {
+    counter = counter || 0;
+    var dataDir = rootDir + 'tmp/' + appName + '-data/';
+
+    console.log('checkIsControllerInstalled...');
+    try {
+        var f = fs.readFileSync(dataDir + 'objects.json');
+        var objects = JSON.parse(f.toString());
+        if (objects['system.adapter.admin.0']) {
+            console.log('checkIsControllerInstalled: installed!');
+            setTimeout(function () {
+                if (cb) cb();
+            }, 100);
+            return;
+        }
+    } catch (err) {
+
+    }
+
+    if (counter > 20) {
+        console.log('checkIsControllerInstalled: Cannot install!');
+        if (cb) cb('Cannot install');
+    } else {
+        console.log('checkIsControllerInstalled: wait...');
+        setTimeout(function() {
+            checkIsControllerInstalled(cb, counter + 1);
+        }, 1000);
+    }
+}
+
+function installAdapter(customName, cb) {
+    if (typeof customName === 'function') {
+        cb = customName;
+        customName = null;
+    }
+    customName = customName || pkg.name.split('.').pop();
+    console.log('Install adapter...');
+    var startFile = 'node_modules/' + appName + '.js-controller/' + appName + '.js';
+    // make first install
+    if (debug) {
+        child_process.execSync('node ' + startFile + ' add ' + customName + ' --enabled false', {
+            cwd:   rootDir + 'tmp',
+            stdio: [0, 1, 2]
+        });
+        checkIsAdapterInstalled(function (error) {
+            if (error) console.error(error);
+            console.log('Adapter installed.');
+            if (cb) cb();
+        });
+    } else {
+        // add controller
+        var _pid = child_process.fork(startFile, ['add', customName, '--enabled', 'false'], {
+            cwd:   rootDir + 'tmp',
+            stdio: [0, 1, 2, 'ipc']
+        });
+
+        waitForEnd(_pid, function () {
+            checkIsAdapterInstalled(function (error) {
+                if (error) console.error(error);
+                console.log('Adapter installed.');
+                if (cb) cb();
+            });
+        });
+    }
+}
+
+function waitForEnd(_pid, cb) {
+    if (!_pid) {
+        cb(-1, -1);
+        return;
+    }
+    _pid.on('exit', function (code, signal) {
+        if (_pid) {
+            _pid = null;
+            cb(code, signal);
+        }
+    });
+    _pid.on('close', function (code, signal) {
+        if (_pid) {
+            _pid = null;
+            cb(code, signal);
+        }
+    });
+}
+
+function installJsController(cb) {
+    console.log('installJsController...');
+    if (!fs.existsSync(rootDir + 'tmp/node_modules/' + appName + '.js-controller') ||
+        !fs.existsSync(rootDir + 'tmp/' + appName + '-data')) {
+        // try to detect appName.js-controller in node_modules/appName.js-controller
+        // travis CI installs js-controller into node_modules
+        if (fs.existsSync(rootDir + 'node_modules/' + appName + '.js-controller')) {
+            console.log('installJsController: no js-controller => copy it from "' + rootDir + 'node_modules/' + appName + '.js-controller"');
+            // copy all
+            // stop controller
+            console.log('Stop controller if running...');
+            var _pid;
+            if (debug) {
+                // start controller
+                _pid = child_process.exec('node ' + appName + '.js stop', {
+                    cwd: rootDir + 'node_modules/' + appName + '.js-controller',
+                    stdio: [0, 1, 2]
+                });
+            } else {
+                _pid = child_process.fork(appName + '.js', ['stop'], {
+                    cwd:   rootDir + 'node_modules/' + appName + '.js-controller',
+                    stdio: [0, 1, 2, 'ipc']
+                });
+            }
+
+            waitForEnd(_pid, function () {
+                // copy all files into
+                if (!fs.existsSync(rootDir + 'tmp')) fs.mkdirSync(rootDir + 'tmp');
+                if (!fs.existsSync(rootDir + 'tmp/node_modules')) fs.mkdirSync(rootDir + 'tmp/node_modules');
+
+                if (!fs.existsSync(rootDir + 'tmp/node_modules/' + appName + '.js-controller')){
+                    console.log('Copy js-controller...');
+                    copyFolderRecursiveSync(rootDir + 'node_modules/' + appName + '.js-controller', rootDir + 'tmp/node_modules/');
+                }
+
+                console.log('Setup js-controller...');
+                var __pid;
+                if (debug) {
+                    // start controller
+                    _pid = child_process.exec('node ' + appName + '.js setup first --console', {
+                        cwd: rootDir + 'tmp/node_modules/' + appName + '.js-controller',
+                        stdio: [0, 1, 2]
+                    });
+                } else {
+                    __pid = child_process.fork(appName + '.js', ['setup', 'first', '--console'], {
+                        cwd:   rootDir + 'tmp/node_modules/' + appName + '.js-controller',
+                        stdio: [0, 1, 2, 'ipc']
+                    });
+                }
+                waitForEnd(__pid, function () {
+                    checkIsControllerInstalled(function () {
+                        // change ports for object and state DBs
+                        var config = require(rootDir + 'tmp/' + appName + '-data/' + appName + '.json');
+                        config.objects.port = 19001;
+                        config.states.port  = 19000;
+                        fs.writeFileSync(rootDir + 'tmp/' + appName + '-data/' + appName + '.json', JSON.stringify(config, null, 2));
+                        console.log('Setup finished.');
+
+                        copyAdapterToController();
+
+                        installAdapter(function () {
+                            storeOriginalFiles();
+                            if (cb) cb(true);
+                        });
+                    });
+                });
+            });
+        } else {
+            // check if port 9000 is free, else admin adapter will be added to running instance
+            var client = new require('net').Socket();
+            client.connect(9000, '127.0.0.1', function() {
+                console.error('Cannot initiate fisrt run of test, because one instance of application is running on this PC. Stop it and repeat.');
+                process.exit(0);
+            });
+
+            setTimeout(function () {
+                client.destroy();
+                if (!fs.existsSync(rootDir + 'tmp/node_modules/' + appName + '.js-controller')) {
+                    console.log('installJsController: no js-controller => install from git');
+
+                    child_process.execSync('npm install https://github.com/' + appName + '/' + appName + '.js-controller/tarball/master --prefix ./  --production', {
+                        cwd:   rootDir + 'tmp/',
+                        stdio: [0, 1, 2]
+                    });
+                } else {
+                    console.log('Setup js-controller...');
+                    var __pid;
+                    if (debug) {
+                        // start controller
+                        child_process.exec('node ' + appName + '.js setup first', {
+                            cwd: rootDir + 'tmp/node_modules/' + appName + '.js-controller',
+                            stdio: [0, 1, 2]
+                        });
+                    } else {
+                        child_process.fork(appName + '.js', ['setup', 'first'], {
+                            cwd:   rootDir + 'tmp/node_modules/' + appName + '.js-controller',
+                            stdio: [0, 1, 2, 'ipc']
+                        });
+                    }
+                }
+
+                // let npm install admin and run setup
+                checkIsControllerInstalled(function () {
+                    var _pid;
+
+                    if (fs.existsSync(rootDir + 'node_modules/' + appName + '.js-controller/' + appName + '.js')) {
+                        _pid = child_process.fork(appName + '.js', ['stop'], {
+                            cwd:   rootDir + 'node_modules/' + appName + '.js-controller',
+                            stdio: [0, 1, 2, 'ipc']
+                        });
+                    }
+
+                    waitForEnd(_pid, function () {
+                        // change ports for object and state DBs
+                        var config = require(rootDir + 'tmp/' + appName + '-data/' + appName + '.json');
+                        config.objects.port = 19001;
+                        config.states.port  = 19000;
+                        fs.writeFileSync(rootDir + 'tmp/' + appName + '-data/' + appName + '.json', JSON.stringify(config, null, 2));
+
+                        copyAdapterToController();
+
+                        installAdapter(function () {
+                            storeOriginalFiles();
+                            if (cb) cb(true);
+                        });
+                    });
+                });
+            }, 1000);
+        }
+    } else {
+        setTimeout(function () {
+            console.log('installJsController: js-controller installed');
+            if (cb) cb(false);
+        }, 0);
+    }
+}
+
+function copyAdapterToController() {
+    console.log('Copy adapter...');
+    // Copy adapter to tmp/node_modules/appName.adapter
+    copyFolderRecursiveSync(rootDir, rootDir + 'tmp/node_modules/', ['.idea', 'test', 'tmp', '.git', appName + '.js-controller']);
+    console.log('Adapter copied.');
+}
+
+function clearControllerLog() {
+    var dirPath = rootDir + 'tmp/log';
+    var files;
+    try {
+        if (fs.existsSync(dirPath)) {
+            console.log('Clear controller log...');
+            files = fs.readdirSync(dirPath);
+        } else {
+            console.log('Create controller log directory...');
+            files = [];
+            fs.mkdirSync(dirPath);
+        }
+    } catch(e) {
+        console.error('Cannot read "' + dirPath + '"');
+        return;
+    }
+    if (files.length > 0) {
+        try {
+            for (var i = 0; i < files.length; i++) {
+                var filePath = dirPath + '/' + files[i];
+                fs.unlinkSync(filePath);
+            }
+            console.log('Controller log cleared');
+        } catch (err) {
+            console.error('cannot clear log: ' + err);
+        }
+    }
+}
+
+function clearDB() {
+    var dirPath = rootDir + 'tmp/iobroker-data/sqlite';
+    var files;
+    try {
+        if (fs.existsSync(dirPath)) {
+            console.log('Clear sqlite DB...');
+            files = fs.readdirSync(dirPath);
+        } else {
+            console.log('Create controller log directory...');
+            files = [];
+            fs.mkdirSync(dirPath);
+        }
+    } catch(e) {
+        console.error('Cannot read "' + dirPath + '"');
+        return;
+    }
+    if (files.length > 0) {
+        try {
+            for (var i = 0; i < files.length; i++) {
+                var filePath = dirPath + '/' + files[i];
+                fs.unlinkSync(filePath);
+            }
+            console.log('Clear sqlite DB');
+        } catch (err) {
+            console.error('cannot clear DB: ' + err);
+        }
+    }
+}
+
+function setupController(cb) {
+    installJsController(function (isInited) {
+        clearControllerLog();
+        clearDB();
+
+        if (!isInited) {
+            restoreOriginalFiles();
+            copyAdapterToController();
+        }
+        if (cb) cb();
+    });
+}
+
+function startAdapter(objects, states, callback) {
+    console.log('startAdapter...');
+    if (fs.existsSync(rootDir + 'tmp/node_modules/' + pkg.name + '/' + pkg.main)) {
+        try {
+            if (debug) {
+                // start controller
+                pid = child_process.exec('node node_modules/' + pkg.name + '/' + pkg.main + ' --console debug', {
+                    cwd: rootDir + 'tmp',
+                    stdio: [0, 1, 2]
+                });
+            } else {
+                // start controller
+                pid = child_process.fork('node_modules/' + pkg.name + '/' + pkg.main, ['--console', 'debug'], {
+                    cwd:   rootDir + 'tmp',
+                    stdio: [0, 1, 2, 'ipc']
+                });
+            }
+        } catch (error) {
+            console.error(JSON.stringify(error));
+        }
+    } else {
+        console.error('Cannot find: ' + rootDir + 'tmp/node_modules/' + pkg.name + '/' + pkg.main);
+    }
+    if (callback) callback(objects, states);
+}
+
+function startController(isStartAdapter, onObjectChange, onStateChange, callback) {
+    if (typeof isStartAdapter === 'function') {
+        onObjectChange = isStartAdapter;
+        isStartAdapter = true;
+    }
+
+    if (onStateChange === undefined) {
+        callback  = onObjectChange;
+        onObjectChange = undefined;
+    }
+
+    if (pid) {
+        console.error('Controller is already started!');
+    } else {
+        console.log('startController...');
+        var isObjectConnected;
+        var isStatesConnected;
+
+        var Objects = require(rootDir + 'tmp/node_modules/' + appName + '.js-controller/lib/objects/objectsInMemServer');
+        objects = new Objects({
+            connection: {
+                "type" : "file",
+                "host" : "127.0.0.1",
+                "port" : 19001,
+                "user" : "",
+                "pass" : "",
+                "noFileCache": false,
+                "connectTimeout": 2000
+            },
+            logger: {
+                debug: function (msg) {
+                    console.log(msg);
+                },
+                info: function (msg) {
+                    console.log(msg);
+                },
+                warn: function (msg) {
+                    console.warn(msg);
+                },
+                error: function (msg) {
+                    console.error(msg);
+                }
+            },
+            connected: function () {
+                isObjectConnected = true;
+                if (isStatesConnected) {
+                    console.log('startController: started!');
+                    if (isStartAdapter) {
+                        startAdapter(objects, states, callback);
+                    } else {
+                        if (callback) callback(objects, states);
+                    }
+                }
+            },
+            change: onObjectChange
+        });
+
+        // Just open in memory DB itself
+        var States = require(rootDir + 'tmp/node_modules/' + appName + '.js-controller/lib/states/statesInMemServer');
+        states = new States({
+            connection: {
+                type: 'file',
+                host: '127.0.0.1',
+                port: 19000,
+                options: {
+                    auth_pass: null,
+                    retry_max_delay: 15000
+                }
+            },
+            logger: {
+                debug: function (msg) {
+                },
+                info: function (msg) {
+                },
+                warn: function (msg) {
+                    console.log(msg);
+                },
+                error: function (msg) {
+                    console.log(msg);
+                }
+            },
+            connected: function () {
+                isStatesConnected = true;
+                if (isObjectConnected) {
+                    console.log('startController: started!!');
+                    startAdapter(objects, states, callback);
+                }
+            },
+            change: onStateChange
+        });
+    }
+}
+
+function stopAdapter(cb) {
+    if (!pid) {
+        console.error('Controller is not running!');
+        if (cb) {
+            setTimeout(function () {
+                cb(false);
+            }, 0);
+        }
+    } else {
+        pid.on('exit', function (code, signal) {
+            if (pid) {
+                console.log('child process terminated due to receipt of signal ' + signal);
+                if (cb) cb();
+                pid = null;
+            }
+        });
+
+        pid.on('close', function (code, signal) {
+            if (pid) {
+                if (cb) cb();
+                pid = null;
+            }
+        });
+
+        pid.kill('SIGTERM');
+    }
+}
+
+function _stopController() {
+    if (objects) {
+        objects.destroy();
+        objects = null;
+    }
+    if (states) {
+        states.destroy();
+        states = null;
+    }
+}
+
+function stopController(cb) {
+    var timeout;
+    if (objects) {
+        console.log('Set system.adapter.' + pkg.name + '.0');
+        objects.setObject('system.adapter.' + pkg.name + '.0', {
+            common:{
+                enabled: false
+            }
+        });
+    }
+
+    stopAdapter(function () {
+        if (timeout) {
+            clearTimeout(timeout);
+            timeout = null;
+        }
+
+        _stopController();
+
+        if (cb) {
+            cb(true);
+            cb = null;
+        }
+    });
+
+    timeout = setTimeout(function () {
+        timeout = null;
+        console.log('child process NOT terminated');
+
+        _stopController();
+
+        if (cb) {
+            cb(false);
+            cb = null;
+        }
+        pid = null;
+    }, 5000);
+}
+
+// Setup the adapter
+function setAdapterConfig(common, native, instance) {
+    var objects = JSON.parse(fs.readFileSync(rootDir + 'tmp/' + appName + '-data/objects.json').toString());
+    var id = 'system.adapter.' + adapterName.split('.').pop() + '.' + (instance || 0);
+    if (common) objects[id].common = common;
+    if (native) objects[id].native = native;
+    fs.writeFileSync(rootDir + 'tmp/' + appName + '-data/objects.json', JSON.stringify(objects));
+}
+
+// Read config of the adapter
+function getAdapterConfig(instance) {
+    var objects = JSON.parse(fs.readFileSync(rootDir + 'tmp/' + appName + '-data/objects.json').toString());
+    var id      = 'system.adapter.' + adapterName.split('.').pop() + '.' + (instance || 0);
+    return objects[id];
+}
+
+if (typeof module !== undefined && module.parent) {
+    module.exports.getAdapterConfig = getAdapterConfig;
+    module.exports.setAdapterConfig = setAdapterConfig;
+    module.exports.startController  = startController;
+    module.exports.stopController   = stopController;
+    module.exports.setupController  = setupController;
+    module.exports.stopAdapter      = stopAdapter;
+    module.exports.startAdapter     = startAdapter;
+    module.exports.installAdapter   = installAdapter;
+    module.exports.appName          = appName;
+    module.exports.adapterName      = adapterName;
+}

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -1,0 +1,140 @@
+/* jshint -W097 */// jshint strict:false
+/*jslint node: true */
+var expect = require('chai').expect;
+var setup  = require(__dirname + '/lib/setup');
+
+var objects = null;
+var states  = null;
+var onStateChanged = null;
+var onObjectChanged = null;
+var sendToID = 1;
+
+var adapterShortName = setup.adapterName.substring(setup.adapterName.indexOf('.')+1);
+
+function checkConnectionOfAdapter(cb, counter) {
+    counter = counter || 0;
+    console.log('Try check #' + counter);
+    if (counter > 30) {
+        if (cb) cb('Cannot check connection');
+        return;
+    }
+
+    states.getState('system.adapter.' + adapterShortName + '.0.alive', function (err, state) {
+        if (err) console.error(err);
+        if (state && state.val) {
+            if (cb) cb();
+        } else {
+            setTimeout(function () {
+                checkConnectionOfAdapter(cb, counter + 1);
+            }, 1000);
+        }
+    });
+}
+
+function checkValueOfState(id, value, cb, counter) {
+    counter = counter || 0;
+    if (counter > 20) {
+        if (cb) cb('Cannot check value Of State ' + id);
+        return;
+    }
+
+    states.getState(id, function (err, state) {
+        if (err) console.error(err);
+        if (value === null && !state) {
+            if (cb) cb();
+        } else
+        if (state && (value === undefined || state.val === value)) {
+            if (cb) cb();
+        } else {
+            setTimeout(function () {
+                checkValueOfState(id, value, cb, counter + 1);
+            }, 500);
+        }
+    });
+}
+
+function sendTo(target, command, message, callback) {
+    onStateChanged = function (id, state) {
+        if (id === 'messagebox.system.adapter.test.0') {
+            callback(state.message);
+        }
+    };
+
+    states.pushMessage('system.adapter.' + target, {
+        command:    command,
+        message:    message,
+        from:       'system.adapter.test.0',
+        callback: {
+            message: message,
+            id:      sendToID++,
+            ack:     false,
+            time:    (new Date()).getTime()
+        }
+    });
+}
+
+describe('Test ' + adapterShortName + ' adapter', function() {
+    before('Test ' + adapterShortName + ' adapter: Start js-controller', function (_done) {
+        this.timeout(600000); // because of first install from npm
+
+        setup.setupController(function () {
+            var config = setup.getAdapterConfig();
+            // enable adapter
+            config.common.enabled  = true;
+            config.common.loglevel = 'debug';
+
+            //config.native.dbtype   = 'sqlite';
+
+            setup.setAdapterConfig(config.common, config.native);
+
+            setup.startController(true, function(id, obj) {}, function (id, state) {
+                    if (onStateChanged) onStateChanged(id, state);
+                },
+                function (_objects, _states) {
+                    objects = _objects;
+                    states  = _states;
+                    _done();
+                });
+        });
+    });
+
+/*
+    ENABLE THIS WHEN ADAPTER RUNS IN DEAMON MODE TO CHECK THAT IT HAS STARTED SUCCESSFULLY
+*/
+    it('Test ' + adapterShortName + ' adapter: Check if adapter started', function (done) {
+        this.timeout(60000);
+        checkConnectionOfAdapter(function (res) {
+            if (res) console.log(res);
+            expect(res).not.to.be.equal('Cannot check connection');
+            objects.setObject('system.adapter.test.0', {
+                    common: {
+
+                    },
+                    type: 'instance'
+                },
+                function () {
+                    states.subscribeMessage('system.adapter.test.0');
+                    done();
+                });
+        });
+    });
+/**/
+
+/*
+    PUT YOUR OWN TESTS HERE USING
+    it('Testname', function ( done) {
+        ...
+    });
+
+    You can also use "sendTo" method to send messages to the started adapter
+*/
+
+    after('Test ' + adapterShortName + ' adapter: Stop js-controller', function (done) {
+        this.timeout(10000);
+
+        setup.stopController(function (normalTerminated) {
+            console.log('Adapter normal terminated: ' + normalTerminated);
+            done();
+        });
+    });
+});

--- a/tr-064.js
+++ b/tr-064.js
@@ -1,4 +1,4 @@
-/* jshint -W097 */// jshint strict:false
+/*jshint esversion: 6 */
 /*jslint node: true */
 'use strict';
 
@@ -207,10 +207,10 @@ TR064.prototype.init = function (callback) {
             self.stateVariables.changeCounter = self.hosts.stateVariables['X_AVM-DE_ChangeCounter'];
 
             self.initIGDDevice(self.ip, self.port, function (err, device) {
-                if (err) adapter.log.error('initIGDDevice:' + (err?err.message:""));
+                if (err) adapter.log.error('initIGDDevice:' + err + ' - ' + JSON.stringify(err));
                 if (!err && device) {
                     getSSLDevice(device, function(err, sslDevice) {
-                        if (err) adapter.log.error('getSSLDevice:' + (err?err.message:""));
+                        if (err) adapter.log.error('getSSLDevice:' + err + ' - ' + JSON.stringify(err));
                         self.getExternalIPAddress = sslDevice.services['urn:schemas-upnp-org:service:WANIPConnection:1'].actions.GetExternalIPAddress;
                         self.reconnectInternet = sslDevice.services['urn:schemas-upnp-org:service:WANIPConnection:1'].actions.ForceTermination;
                     });
@@ -228,7 +228,7 @@ TR064.prototype.forEachHostEntry = function (callback) {
 
     adapter.log.debug('forEachHostEntry');
     self.hosts.actions.GetHostNumberOfEntries(function (err, obj) {
-        if (err) adapter.log.error('GetHostNumberOfEntries:' + (err?err.message:""));
+        if (err) adapter.log.error('GetHostNumberOfEntries:' + err + ' - ' + JSON.stringify(err));
         if (err || !obj) return;
         var all = obj.NewHostNumberOfEntries >> 0;
         adapter.log.debug('forEachHostEntry: all=' + all);
@@ -239,7 +239,7 @@ TR064.prototype.forEachHostEntry = function (callback) {
                 return;
             }
             self.getGenericHostEntry({NewIndex: cnt}, function (err, obj) {
-                if (err) adapter.log.error('forEachHostEntry: in getGenericHostEntry ' + (cnt) + ':' + (err?err.message:""));
+                if (err) adapter.log.error('forEachHostEntry: in getGenericHostEntry ' + (cnt) + ':' + err + ' - ' + JSON.stringify(err));
                 if (err || !obj) return;
                 adapter.log.debug('forEachHostEntry cnt=' + cnt + ' ' + obj.NewHostName);
                 callback(err, obj, cnt++, all);
@@ -265,7 +265,7 @@ TR064.prototype.forEachConfiguredDevice = function (callback) {
         if (dev.mac && dev.mac !== "") {
             self.getSpecificHostEntry({NewMACAddress: dev.mac}, function (err, device) {
             //self.GetSpecificHostEntryExt({NewMACAddress: dev.mac}, function (err, device) {
-                if (err) adapter.log.error('forEachConfiguredDevice: in GetSpecificHostEntryExt ' + (i-1) + '(' + dev.name + '/' + dev.mac + '):' + JSON.stringify(err));
+                if (err) adapter.log.error('forEachConfiguredDevice: in GetSpecificHostEntryExt ' + (i-1) + '(' + dev.name + '/' + dev.mac + '):' + err + ' - ' + JSON.stringify(err));
                 if (!err && device) {
                     adapter.log.debug('forEachConfiguredDevice: i=' + (i-1) + ' ' + device.NewHostName + ' active=' + device.NewActive);
                     device.NewMACAddress = dev.mac;
@@ -297,7 +297,7 @@ TR064.prototype.setWLAN24 = function (val, callback) {
 TR064.prototype.setWLAN50 = function (val, callback) {
     var self = this;
     this.getWLANConfiguration2.actions.SetEnable({ 'NewEnable': val ? 1 : 0 }, function (err, result) {
-        if (err) adapter.log.error('getWLANConfiguration2:' + (err?err.message:""));
+        if (err) adapter.log.error('getWLANConfiguration2:' + err + ' - ' + JSON.stringify(err));
         //if (!val) setTimeout(function (err, res) {
         //    self.setWLAN(true, function (err, res) {
         //    });
@@ -312,10 +312,10 @@ TR064.prototype.setWLANGuest = function (val, callback) {
 TR064.prototype.setWLAN = function (val, callback) {
     var self = this;
     this.setWLAN24(val, function (err, result) {
-        if (err) adapter.log.error('setWLAN24:' + (err?err.message:""));
+        if (err) adapter.log.error('setWLAN24:' + err + ' - ' + JSON.stringify(err));
         if (err || !result) return callback(-1);
         self.setWLANGuest(val, function (err, result) {
-            if (err) adapter.log.error('setWLANGuest:' + (err?err.message:""));
+            if (err) adapter.log.error('setWLANGuest:' + err + ' - ' + JSON.stringify(err));
             self.setWLAN50(val, callback);
         });
     });
@@ -519,8 +519,10 @@ function main() {
 
     tr064Client = new TR064(adapter.config.user, adapter.config.password, adapter.config.ip);
     tr064Client.init(function (err) {
-        if (err) adapter.log.error('main - init:' + (err?err.message:""));
-        if (err) return;
+        if (err) {
+            adapter.log.error('main - init:' + err + ' - ' + JSON.stringify(err));
+            return;
+        }
         createConfiguredDevices(function(err) {
             phonebook.start(tr064Client.sslDevice, { return: !adapter.config.usePhonebook }, function() {
                 if (pollingTimer) clearTimeout(pollingTimer);

--- a/tr-064.js
+++ b/tr-064.js
@@ -1,4 +1,6 @@
-"use strict";
+/* jshint -W097 */// jshint strict:false
+/*jslint node: true */
+'use strict';
 
 var //utils       = require(__dirname + '/lib/utils'),
     phonebook   = require(__dirname + '/lib/phonebook'),
@@ -10,6 +12,7 @@ var //utils       = require(__dirname + '/lib/utils'),
 var tr064Client;
 var commandDesc = 'eg. { "service": "urn:dslforum-org:service:WLANConfiguration:1", "action": "X_AVM-DE_SetWPSConfig", "params": { "NewX_AVM-DE_WPSMode": "pbc", "NewX_AVM-DE_WPSClientPIN": "" } }';
 var debug = false;
+var pollingTimer = null;
 
 var adapter = soef.Adapter(
     onStateChange,
@@ -128,7 +131,7 @@ function onMessage (obj) {
 function onStateChange (id, state) {
     var as = id.split('.');
     if ((as[0] + '.' + as[1] != adapter.namespace) || (as[2] !== CHANNEL_STATES)) return;
-    adapter.log.info('stateChange ' + id + ' ' + JSON.stringify(state));
+    adapter.log.debug('stateChange ' + id + ' ' + JSON.stringify(state));
 
     //var dev = devices.get (id.substr(adapter.namespace.length+1));
     var func = states [as[3]] && states [as[3]].native ? states [as[3]].native.func : null;
@@ -170,11 +173,11 @@ TR064.prototype.init = function (callback) {
 
     function getSSLDevice(device, callback) {
         return callback(null, device);
-        device.startEncryptedCommunication(function(err, sslDevice) {
+/*        device.startEncryptedCommunication(function(err, sslDevice) {
             if (err || !sslDevice) callback(err);
             sslDevice.login(self.user, self.password);
             callback(null, sslDevice);
-        });
+        });*/
     }
 
     self.initTR064Device(self.ip, self.port, function (err, device) {
@@ -203,8 +206,10 @@ TR064.prototype.init = function (callback) {
             self.stateVariables.changeCounter = self.hosts.stateVariables['X_AVM-DE_ChangeCounter'];
 
             self.initIGDDevice(self.ip, self.port, function (err, device) {
+                if (err) adapter.log.error('initIGDDevice:' + (err?err.message:""));
                 if (!err && device) {
                     getSSLDevice(device, function(err, sslDevice) {
+                        if (err) adapter.log.error('getSSLDevice:' + (err?err.message:""));
                         self.getExternalIPAddress = sslDevice.services['urn:schemas-upnp-org:service:WANIPConnection:1'].actions.GetExternalIPAddress;
                         self.reconnectInternet = sslDevice.services['urn:schemas-upnp-org:service:WANIPConnection:1'].actions.ForceTermination;
                     });
@@ -222,6 +227,7 @@ TR064.prototype.forEachHostEntry = function (callback) {
 
     adapter.log.debug('forEachHostEntry');
     self.hosts.actions.GetHostNumberOfEntries(function (err, obj) {
+        if (err) adapter.log.error('GetHostNumberOfEntries:' + (err?err.message:""));
         if (err || !obj) return;
         var all = obj.NewHostNumberOfEntries >> 0;
         adapter.log.debug('forEachHostEntry: all=' + all);
@@ -232,6 +238,7 @@ TR064.prototype.forEachHostEntry = function (callback) {
                 return;
             }
             self.getGenericHostEntry({NewIndex: cnt}, function (err, obj) {
+                if (err) adapter.log.error('forEachHostEntry: in getGenericHostEntry ' + (cnt) + ':' + (err?err.message:""));
                 if (err || !obj) return;
                 adapter.log.debug('forEachHostEntry cnt=' + cnt + ' ' + obj.NewHostName);
                 callback(err, obj, cnt++, all);
@@ -250,20 +257,22 @@ TR064.prototype.forEachConfiguredDevice = function (callback) {
 
     function doIt() {
         if (i >= adapter.config.devices.length) {
+            callback (null, true); // make sure to call callback also when last device is not successfull
             return;
         }
         var dev = adapter.config.devices[i++];
-        if (dev.mac && dev.mac != "") {
+        if (dev.mac && dev.mac !== "") {
             self.getSpecificHostEntry({NewMACAddress: dev.mac}, function (err, device) {
             //self.GetSpecificHostEntryExt({NewMACAddress: dev.mac}, function (err, device) {
-                //adapter.log.debug('forEachConfiguredDevice: in GetSpecificHostEntryExt ' + (err?err.message:""));
+                if (err) adapter.log.error('forEachConfiguredDevice: in GetSpecificHostEntryExt ' + (i-1) + '(' + dev.name + '/' + dev.mac + '):' + JSON.stringify(err));
                 if (!err && device) {
                     adapter.log.debug('forEachConfiguredDevice: i=' + (i-1) + ' ' + device.NewHostName + ' active=' + device.NewActive);
                     device.NewMACAddress = dev.mac;
                     callback (device, i >= adapter.config.devices.length);
+                    if (i >= adapter.config.devices.length) return;
                 }
                 setTimeout(doIt, 0);
-            })
+            });
         } else {
             setTimeout(doIt, 0);
         }
@@ -276,7 +285,6 @@ TR064.prototype.command = function (command, callback) {
     var o = JSON.parse(command);
     this.sslDevice.services[o.service].actions[o.action](o.params, function (err, res) {
         if (err || !res) return;
-        adapter.log.info(JSON.stringify(res));
         adapter.setState(states.states.name + '.' + states.commandResult.name, JSON.stringify(res), true);
     });
 };
@@ -288,6 +296,7 @@ TR064.prototype.setWLAN24 = function (val, callback) {
 TR064.prototype.setWLAN50 = function (val, callback) {
     var self = this;
     this.getWLANConfiguration2.actions.SetEnable({ 'NewEnable': val ? 1 : 0 }, function (err, result) {
+        if (err) adapter.log.error('getWLANConfiguration2:' + (err?err.message:""));
         //if (!val) setTimeout(function (err, res) {
         //    self.setWLAN(true, function (err, res) {
         //    });
@@ -302,8 +311,10 @@ TR064.prototype.setWLANGuest = function (val, callback) {
 TR064.prototype.setWLAN = function (val, callback) {
     var self = this;
     this.setWLAN24(val, function (err, result) {
+        if (err) adapter.log.error('setWLAN24:' + (err?err.message:""));
         if (err || !result) return callback(-1);
         self.setWLANGuest(val, function (err, result) {
+            if (err) adapter.log.error('setWLANGuest:' + (err?err.message:""));
             self.setWLAN50(val, callback);
         });
     });
@@ -326,6 +337,9 @@ var errorCounts = {};
 function _checkError(err, res) {
     if (err) {
         var code = err.code ? err.code : 'unknown error code';
+        if (errorCounts [code] && (new Date().getTime()-errorCounts [code])>/*24**/60*60*1000) {
+            delete(errorCounts [code]);
+        }
         if (!errorCounts [code]) {
             var msg = err.message ? err.message : 'unknown error text';
             switch (code >> 0) {
@@ -334,7 +348,7 @@ function _checkError(err, res) {
                     break;
             }
             adapter.log.error('code=' + code + ' ' + msg);
-            errorCounts [code] = 1;
+            errorCounts [code] = new Date().getTime();
         }
     }
     this (err, res);
@@ -366,7 +380,7 @@ TR064.prototype.dialNumber = function (number, callback) {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 function isKnownMac(mac) {
-    return !!adapter.config.devices.find(function(v) { return v.mac === mac} );
+    return !!adapter.config.devices.find(function(v) { return v.mac === mac;} );
 }
 
 function deleteUnusedDevices(callback) {
@@ -385,7 +399,7 @@ function deleteUnusedDevices(callback) {
         toDelete.forEach(function (id) {
             adapter.log.debug('deleting ' + id);
             res.rows.forEach(function(o) {
-                if (o.id.indexOf(id) == 0) {
+                if (o.id.indexOf(id) === 0) {
                     devices.remove(o.id.substr(adapter.namespace.length+1));
                     adapter.states.delState(o.id, function(err, obj) {
                          adapter.objects.delObject(o.id);
@@ -418,8 +432,10 @@ function createConfiguredDevices(callback) {
     adapter.log.debug('createConfiguredDevices');
     var dev = new devices.CDevice(CHANNEL_DEVICES, '');
     tr064Client.forEachConfiguredDevice(function(device, isLast) {
-        dev.setChannelEx(device.NewHostName, { common: { name: device.NewHostName + ' (' + device.NewIPAddress + ')', role: 'channel' }, native: { mac: device.NewMACAddress }} );
-        setActive(dev, device.NewActive);
+        if (device) {
+            dev.setChannelEx(device.NewHostName, { common: { name: device.NewHostName + ' (' + device.NewIPAddress + ')', role: 'channel' }, native: { mac: device.NewMACAddress }} );
+            setActive(dev, device.NewActive);
+        }
         if (isLast) {
             devices.update(callback);
         }
@@ -431,8 +447,11 @@ function updateDevices(callback) {
     var dev = new devices.CDevice(CHANNEL_DEVICES, '');
 
     tr064Client.forEachConfiguredDevice(function(device, isLast) {
-        dev.setChannelEx(device.NewHostName);
-        setActive(dev, device.NewActive);
+        adapter.log.debug('forEachConfiguredDevice: ' + JSON.stringify(device) + ', last=' + isLast);
+        if (device) {
+            dev.setChannelEx(device.NewHostName);
+            setActive(dev, device.NewActive);
+        }
         if (isLast) {
             devices.update(callback);
         }
@@ -440,12 +459,12 @@ function updateDevices(callback) {
 }
 
 function updateAll(cb) {
-    //adapter.log.debug('in updateAll');
+    adapter.log.debug('in updateAll');
     const names = [
-        { func: 'getExternalIPAddress', state: states.externalIP.name, result: 'NewExternalIPAddress', format: function(val) { return val }},
-        { func: 'getWLAN', state: states.wlan24.name, result: 'NewEnable', format: function(val) { return !!(val >> 0)}},
-        { func: 'getWLAN5', state: states.wlan50.name, result: 'NewEnable', format: function(val) { return !!(val >> 0)}},
-        { func: 'getWLANGuest', state: states.wlanGuest.name, result: 'NewEnable', format: function(val) { return !!(val >> 0)}}
+        { func: 'getExternalIPAddress', state: states.externalIP.name, result: 'NewExternalIPAddress', format: function(val) { return val; }},
+        { func: 'getWLAN', state: states.wlan24.name, result: 'NewEnable', format: function(val) { return !!(val >> 0);}},
+        { func: 'getWLAN5', state: states.wlan50.name, result: 'NewEnable', format: function(val) { return !!(val >> 0);}},
+        { func: 'getWLANGuest', state: states.wlanGuest.name, result: 'NewEnable', format: function(val) { return !!(val >> 0);}}
     ];
     var i = 0;
 
@@ -453,8 +472,10 @@ function updateAll(cb) {
         if (i >= names.length) {
             devStates.set('reboot', false);
             devices.update(function(err) {
+                if (err && err !== -1) adapter.log.error('updateAll:' + err);
                 if (adapter.config.pollingInterval) {
-                    setTimeout(updateAll, adapter.config.pollingInterval*1000);
+                    if (pollingTimer) clearTimeout(pollingTimer);
+                    pollingTimer = setTimeout(updateAll, adapter.config.pollingInterval*1000);
                 }
             });
             return;
@@ -496,10 +517,12 @@ function main() {
 
     tr064Client = new TR064(adapter.config.user, adapter.config.password, adapter.config.ip);
     tr064Client.init(function (err) {
+        if (err) adapter.log.error('main - init:' + (err?err.message:""));
         if (err) return;
         createConfiguredDevices(function(err) {
             phonebook.start(tr064Client.sslDevice, { return: !adapter.config.usePhonebook }, function() {
-                updateAll();
+                if (pollingTimer) clearTimeout(pollingTimer);
+                pollingTimer = setTimeout(updateAll, 2000);
                 callMonitor(adapter, devices, phonebook);
             });
         });
@@ -507,4 +530,3 @@ function main() {
 
     adapter.subscribeStates('*');
 }
-

--- a/tr-064.js
+++ b/tr-064.js
@@ -2,6 +2,7 @@
 /*jslint node: true */
 'use strict';
 
+/* global devices */
 var //utils       = require(__dirname + '/lib/utils'),
     phonebook   = require(__dirname + '/lib/phonebook'),
     callMonitor = require(__dirname + '/lib/callmonitor'),
@@ -51,8 +52,8 @@ var adapter = soef.Adapter(
 //});
 
 
-const CHANNEL_STATES = 'states',
-      CHANNEL_DEVICES = 'devices';
+var CHANNEL_STATES = 'states',
+    CHANNEL_DEVICES = 'devices';
 
 var devStates;
 var allDevices = [];
@@ -351,6 +352,7 @@ function _checkError(err, res) {
             errorCounts [code] = new Date().getTime();
         }
     }
+    /* jshint validthis: true */
     this (err, res);
 }
 
@@ -460,7 +462,7 @@ function updateDevices(callback) {
 
 function updateAll(cb) {
     adapter.log.debug('in updateAll');
-    const names = [
+    var names = [
         { func: 'getExternalIPAddress', state: states.externalIP.name, result: 'NewExternalIPAddress', format: function(val) { return val; }},
         { func: 'getWLAN', state: states.wlan24.name, result: 'NewEnable', format: function(val) { return !!(val >> 0);}},
         { func: 'getWLAN5', state: states.wlan50.name, result: 'NewEnable', format: function(val) { return !!(val >> 0);}},

--- a/tr-064.js
+++ b/tr-064.js
@@ -52,8 +52,8 @@ var adapter = soef.Adapter(
 //});
 
 
-var CHANNEL_STATES = 'states',
-    CHANNEL_DEVICES = 'devices';
+const CHANNEL_STATES = 'states',
+      CHANNEL_DEVICES = 'devices';
 
 var devStates;
 var allDevices = [];
@@ -462,7 +462,7 @@ function updateDevices(callback) {
 
 function updateAll(cb) {
     adapter.log.debug('in updateAll');
-    var names = [
+    const names = [
         { func: 'getExternalIPAddress', state: states.externalIP.name, result: 'NewExternalIPAddress', format: function(val) { return val; }},
         { func: 'getWLAN', state: states.wlan24.name, result: 'NewEnable', format: function(val) { return !!(val >> 0);}},
         { func: 'getWLAN5', state: states.wlan50.name, result: 'NewEnable', format: function(val) { return !!(val >> 0);}},


### PR DESCRIPTION
- in updateDevices there was a race condition with the sand callbacks
when the last host entry was not successfully returned - then the
callback was not called and so the timeout was not set for the next
cycle … means that the adapter did not checked anything anymore
- made sure by using a pollingTimer variable that only one timeout for
the next cycle is running. there were cases where multiple timeouts
were running (high load)
- change some small coding style things on jslint advice
- commented out dead code (return before code, so was never called at
all)
- added some more error logging to get infos on errors to show error transparent in the log because they should be fixed, or ?!
- also start very first „updateAll“ call by a timeout because I had
cases where it was started multiple times initially
- add basic adapter testing with Travis-CI and Appveyor (see https://ci.appveyor.com/project/Apollon77/iobroker-tr-064 and https://travis-ci.org/Apollon77/ioBroker.tr-064)
- add README note on supported node versions (4.x+)