### PR TITLE
callmonitor.js: Add calleeName

### DIFF
--- a/lib/callmonitor.js
+++ b/lib/callmonitor.js
@@ -105,13 +105,21 @@ module.exports = function (adapter, devices, phonebook) {
                     var pbe = phonebook.byNumber(message.caller);
                     if (pbe) {
                         message.callerName = pbe.name;
-                        if (pbe.imageurl) message.imageurl = pbe.imageurl;
+                        if (pbe.imageurl) message.imageurlcaller = pbe.imageurl;
                     }
                 }
                 dev.set('callerName', message.callerName);
+                if (message.calleeName === undefined && message.callee) {
+                    var pbee = phonebook.byNumber(message.callee);
+                    if (pbee) {
+                        message.calleeName = pbee.name;
+                        if (pbee.imageurl) message.imageurlcallee = pbee.imageurl;
+                    }
+                }
+                dev.set('calleeName', message.calleeName);
             }
             dev.set('json', JSON.stringify(message));
-            adapter.log.debug('callMonitor.set: type=' + name + ' caller=' + message.caller + ' callee=' + message.callee + (message.callerName ? ' callerName=' + message.callerName : ''));
+            adapter.log.debug('callMonitor.set: type=' + name + ' caller=' + message.caller + ' callee=' + message.callee + (message.callerName ? ' callerName=' + message.callerName : '') + (message.calleeName ? ' calleeName=' + message.calleeName : ''));
             timer = setTimeout(function() {
                 devices.update();
             }, 500);


### PR DESCRIPTION
Especially for outgoing calls but also to differentiate callee numbers/names for incoming calls, the callee name would be very useful.